### PR TITLE
Reverting paths.  Fixing build

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -1,8 +1,8 @@
 @charset "utf-8";
 
 @import 'base/settings';
-@import 'normalize';
-@import 'foundation/components/grid';
-@import 'foundation/components/block-grid';
-@import 'foundation/components/type';
-@import 'foundation/components/visibility';
+@import '../bower_components/foundation/_scss/normalize';
+@import '../bower_components/foundation/_scss/foundation/components/grid';
+@import '../bower_components/foundation/_scss/foundation/components/block-grid';
+@import '../bower_components/foundation/_scss/foundation/components/type';
+@import '../bower_components/foundation/_scss/foundation/components/visibility';

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,7 +33,7 @@ gulp.task('jekyll:serve', shell.task([
 ]));
 
 gulp.task('jekyll:build', shell.task([
-  'jekyll build . --trace'
+  'jekyll build . --trace --safe'
 ]));
 
 gulp.task('lint', function () {


### PR DESCRIPTION
Also updated gulp jekyll build command to use safe flag to view build errors locally.  See:
https://help.github.com/articles/troubleshooting-github-pages-build-failures/